### PR TITLE
Allow pickle in np.load

### DIFF
--- a/s2dhm/datasets/base_dataset.py
+++ b/s2dhm/datasets/base_dataset.py
@@ -134,7 +134,7 @@ class BaseDataset():
             data (intrinsics matrix, distortion coefficients, 2D and 3D points)
         """
         assert os.path.isfile(self._data['triangulation_data_file'])
-        triangulation_data = np.load(self._data['triangulation_data_file'])
+        triangulation_data = np.load(self._data['triangulation_data_file'], allow_pickle=True)
         filename_to_local_reconstruction = dict()
         for filename in self._data['reference_image_names']:
             key = self.key_converter(filename)


### PR DESCRIPTION
The default value in `np.load(...)` for the keyword argument `allow_pickle` changed to False beginning with numpy version 1.16.3, therefore we have to set it to True explicitly. 

Alternatively, the numpy version could be restricted to be "<=1.16.3"

See: https://numpy.org/devdocs/reference/generated/numpy.load.html
